### PR TITLE
don't use deprecated `Build.Step.Compile.linkLibC`

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -20,10 +20,10 @@ pub fn build(b: *std.Build) void {
             .root_source_file = b.path("test/main.zig"),
             .optimize = optimize,
             .target = target,
+            .link_libc = true,
         }),
     });
 
-    tests.linkLibC();
     tests.root_module.addImport("lmdb", lmdb);
     const test_runner = b.addRunArtifact(tests);
 
@@ -36,10 +36,10 @@ pub fn build(b: *std.Build) void {
             .root_source_file = b.path("benchmarks/main.zig"),
             .optimize = optimize,
             .target = target,
+            .link_libc = true,
         }),
     });
 
-    bench.linkLibC();
     bench.root_module.addImport("lmdb", lmdb);
 
     const bench_runner = b.addRunArtifact(bench);
@@ -52,10 +52,10 @@ pub fn build(b: *std.Build) void {
             .root_source_file = b.path("example.zig"),
             .optimize = optimize,
             .target = target,
+            .link_libc = true,
         }),
     });
 
-    exe.linkLibC();
     exe.root_module.addImport("lmdb", lmdb);
 
     const exe_runner = b.addRunArtifact(exe);


### PR DESCRIPTION
Keeping up with nightly builds. This was already marked as deprecated during the 0.15 release cycle and recently removed: https://codeberg.org/ziglang/zig/commit/39fa8319478e4843d5384e81935520be2dbbadef#diff-9ac6e9af21ac014ec34ad6bf890f2fac7acadb62